### PR TITLE
Return confirmation that was accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ steamcommunityMobileConfirmations.FetchConfirmations((function (err, confirmatio
 	{
 		return;
 	}
-	this.steamcommunityMobileConfirmations.AcceptConfirmation(confirmations[0], (function (err, result)
+	this.steamcommunityMobileConfirmations.AcceptConfirmation(confirmations[0], (function (err, result, confirmation)
 	{
 		if (err)
 		{
 			console.log(err);
 			return;
 		}
-		console.log('steamcommunityMobileConfirmations.AcceptConfirmation result: ' + result);
+		console.log('steamcommunityMobileConfirmations.AcceptConfirmation for trade #' + confirmation.id + ' result: ' + result);
 	}).bind(this));
 }).bind(this));
 ```

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ SteamcommunityMobileConfirmations.prototype._sendConfirmationAjax = function (co
 		try
 		{
 			var result = JSON.parse(body);
-			callback(null, result.success);
+			callback(null, result.success, confirmation);
 		}
 		catch (e)
 		{


### PR DESCRIPTION
This update makes AcceptConfirmation() return the confirmation that was accepted. This is useful for tracking which confirmations have been accepted vs those that haven't without calling FetchConfirmations(). 
